### PR TITLE
Added primitive error handling when some methods fail to calculate

### DIFF
--- a/R/Calculate_score.R
+++ b/R/Calculate_score.R
@@ -7,11 +7,11 @@
 #' @param method a parameter to specify which models to use to calculate the synergy scores. Choices are "ZIP",
 #' "Bliss", "HSA" and "Loewe". Defaults to "ZIP".
 #' @param correction a parameter to specify if baseline correction is used or not. Defaults to TRUE.
-#' @param correction.fixed a parameter to specify which parameters of L.4 or LL.4 functions are fixed and at what value they are fixed for 
+#' @param correction.fixed a parameter to specify which parameters of L.4 or LL.4 functions are fixed and at what value they are fixed for
 #' baseline correction. NAs for parameter that are not fixed. More details in function \code{\link[drc]{drm}}.
-#' @param single.fixed a parameter to specify which parameters of L.4 or LL.4 functions are fixed and at what value they are fixed for 
+#' @param single.fixed a parameter to specify which parameters of L.4 or LL.4 functions are fixed and at what value they are fixed for
 #' single dose-response fitting. NAs for parameter that are not fixed. More details in function \code{\link[drc]{drm}}. It is only required by ZIP model.
-#' @param ZIP.Emax the maximal inhibition of the drugs when applying ZIP model. By default, it is not fixed. 
+#' @param ZIP.Emax the maximal inhibition of the drugs when applying ZIP model. By default, it is not fixed.
 #' @param nan.handle a parameter to specify if L.4 function or LL.4 function is used when fitting with LL.4 produces
 #' NaNs.
 #' @return a list of the following components:
@@ -26,7 +26,7 @@
 #' data("mathews_screening_data")
 #' data <- ReshapeData(mathews_screening_data)
 #' scores <- CalculateSynergy(data)
-CalculateSynergy <- function(data, method = "ZIP", correction = TRUE, correction.fixed = c(NA, NA, NA, NA), single.fixed = c(NA, NA, NA, NA), 
+CalculateSynergy <- function(data, method = "ZIP", correction = TRUE, correction.fixed = c(NA, NA, NA, NA), single.fixed = c(NA, NA, NA, NA),
                              ZIP.Emax = NA, nan.handle = c("LL4", "L4")) {
   if(!is.list(data)) {
     stop("Input data is not a list format!")
@@ -39,17 +39,19 @@ CalculateSynergy <- function(data, method = "ZIP", correction = TRUE, correction
   scores <- list() ## save delta scores for each drug combination
   nan.handle <- match.arg(nan.handle)
   for (i in 1:num.pairs) {
-    response.mat <- dose.response.mats[[i]]
-    scores[[i]] <- switch(method,
+      response.mat <- dose.response.mats[[i]]
+      ###added zeroes out matrix by default
+      scores[[i]]<-matrix(0,nrow=nrow(response.mat),ncol=ncol(response.mat))
+      ###then added try statement in case the method fails
+      try(scores[[i]] <- switch(method,
                           ZIP = ZIP(response.mat, correction, correction.fixed, single.fixed,
                                     ZIP.Emax, nan.handle),
                           HSA = HSA(response.mat, correction, correction.fixed, nan.handle),
                           Bliss = Bliss(response.mat, correction, correction.fixed, nan.handle),
-                          Loewe = Loewe(response.mat, correction, correction.fixed, nan.handle))
+                          Loewe = Loewe(response.mat, correction, correction.fixed, nan.handle)) <-
   }
 
   data$scores <- scores
   data$method <- method
   return(data)
 }
-

--- a/R/Calculate_score.R
+++ b/R/Calculate_score.R
@@ -48,7 +48,7 @@ CalculateSynergy <- function(data, method = "ZIP", correction = TRUE, correction
                                     ZIP.Emax, nan.handle),
                           HSA = HSA(response.mat, correction, correction.fixed, nan.handle),
                           Bliss = Bliss(response.mat, correction, correction.fixed, nan.handle),
-                          Loewe = Loewe(response.mat, correction, correction.fixed, nan.handle)) <-
+                          Loewe = Loewe(response.mat, correction, correction.fixed, nan.handle)))
   }
 
   data$scores <- scores


### PR DESCRIPTION
I had trouble with my own data when some methods (ZIP and Loewe) would fail causing the entire list of combinations to be unpopulated. By adding in a zero-ed matrix before calling the synergy calculation within a `try()` block I could retrieve most calculations. 